### PR TITLE
Features/recipient popup closing stage

### DIFF
--- a/src/features/create-request/model/create-request.ts
+++ b/src/features/create-request/model/create-request.ts
@@ -46,6 +46,9 @@ export const createRequestModel = createSlice({
     setTime(state, action) {
       state.time = action.payload;
     },
+    clearTime(state, action) {
+      state.time = '';
+    },
     setAddress(state, action) {
       state.address = action.payload.additinalAddress;
       state.coordinates = action.payload.coords;
@@ -93,4 +96,5 @@ export const {
   changeCheckbox,
   openPopup,
   closePopup,
+  clearTime,
 } = createRequestModel.actions;

--- a/src/features/create-request/model/create-request.ts
+++ b/src/features/create-request/model/create-request.ts
@@ -81,6 +81,9 @@ export const createRequestModel = createSlice({
       state.currentStep = InitialStateForPopup.currentStep;
       state.isPopupOpen = false;
     },
+    clearState(state) {
+      Object.assign(state, InitialStateForPopup);
+    },
   },
 });
 
@@ -97,4 +100,5 @@ export const {
   openPopup,
   closePopup,
   clearTime,
+  clearState,
 } = createRequestModel.actions;

--- a/src/features/create-request/ui/steps/common-step/common-step.tsx
+++ b/src/features/create-request/ui/steps/common-step/common-step.tsx
@@ -1,7 +1,11 @@
 import classNames from 'classnames';
 
 import { useAppDispatch, useAppSelector } from 'app/hooks';
-import { changeStepDecrement, closePopup } from 'features/create-request/model';
+import {
+  changeStepDecrement,
+  clearState,
+  closePopup,
+} from 'features/create-request/model';
 import { Button } from 'shared/ui/button';
 import { LocationIcon } from 'shared/ui/icons/location-icon';
 import { CategoriesBackground } from 'shared/ui/categories-background';
@@ -26,6 +30,7 @@ export const CommonStep = ({ isMobile }: ICommonStepProps) => {
     console.log(
       `время: ${time} адрес: ${address} категория: ${category.label} описание:${descriptionForTask} дата: ${date}`
     );
+    dispatch(clearState());
     dispatch(closePopup());
   };
 

--- a/src/features/create-request/ui/steps/common-step/common-step.tsx
+++ b/src/features/create-request/ui/steps/common-step/common-step.tsx
@@ -23,6 +23,9 @@ export const CommonStep = ({ isMobile }: ICommonStepProps) => {
   };
 
   const handleSubmitClick = () => {
+    console.log(
+      `время: ${time} адрес: ${address} категория: ${category.label} описание:${descriptionForTask} дата: ${date}`
+    );
     dispatch(closePopup());
   };
 

--- a/src/features/create-request/ui/steps/date-step/date-step.tsx
+++ b/src/features/create-request/ui/steps/date-step/date-step.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { format, parse } from 'date-fns';
 
@@ -8,6 +8,7 @@ import {
   setTime,
   changeCheckbox,
   changeStepIncrement,
+  clearTime,
 } from 'features/create-request/model';
 import { Button } from 'shared/ui/button';
 import Checkbox from 'shared/ui/checkbox';
@@ -24,6 +25,8 @@ export const DateStep = ({ isMobile }: IDateStepProps) => {
     (state) => state.createRequest
   );
   const dispatch = useAppDispatch();
+  // const [inputValue, setInputValue] = useState('');
+  // const [isTimePassed, setIsTimePassed] = useState(false);
 
   const handleDateValueChange = (value: Date) => {
     const formatedDate = format(value, 'dd.MM.yyyy');
@@ -31,8 +34,46 @@ export const DateStep = ({ isMobile }: IDateStepProps) => {
   };
 
   const handleTimeValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const currentTime = new Date(); // текущая дата
+    const currentFormattedTime = format(currentTime, 'HH:mm'); // привожу в нужный формат
+    const selectedTime = new Date(`1970-01-01T${e.target.value}:00`); //фиктивная дата '1970-01-01', чтобы установить только время, а не дату
+    const selectedFormattedTime = format(selectedTime, 'HH:mm'); // привожу в нужный формат
+    //
+    if (time < currentFormattedTime) {
+      // console.log('время меньше');
+      console.log(selectedFormattedTime);
+      console.log(currentFormattedTime);
+
+      dispatch(setTime(currentFormattedTime));
+      return;
+    } //сравниваю даты
+    // console.log('время норм');
     dispatch(setTime(e.target.value));
+    // setInputValue(e.target.value);
   };
+
+  // useEffect(() => {
+  //   const currentTime = new Date(); // текущая дата
+  //   const currentFormattedTime = format(currentTime, 'HH:mm'); // привожу в нужный формат
+  //   // const selectedTime = new Date(`1970-01-01T${time}:00`); //фиктивная дата '1970-01-01', чтобы установить только время, а не дату
+  //   // const selectedFormattedTime = format(selectedTime, 'HH:mm'); // привожу в нужный формат
+  //   if (time && time < currentFormattedTime) {
+  //     console.log('время меньше');
+  //     console.log(currentFormattedTime);
+  //
+  //     dispatch(setTime(currentFormattedTime));
+  //   } //сравниваю даты
+  // }, [time]);
+  // useEffect(() => {
+  //   const inputTime = new Date(inputValue);
+  //   const currentTime = new Date();
+  //
+  //   if (inputTime < currentTime) {
+  //     setIsTimePassed(true);
+  //   } else {
+  //     setIsTimePassed(false);
+  //   }
+  // }, [inputValue]);
 
   const handleNextStepClick = () => {
     dispatch(changeStepIncrement());
@@ -59,6 +100,7 @@ export const DateStep = ({ isMobile }: IDateStepProps) => {
             id="time"
             name="time"
             onChange={handleTimeValueChange}
+            // value={time}
             value={time}
             required
             className={classNames(
@@ -78,6 +120,7 @@ export const DateStep = ({ isMobile }: IDateStepProps) => {
             onChangeValue={handleDateValueChange}
             value={dateValue}
             isMobile={isMobile}
+            disabled={termlessRequest}
           />
         </div>
         <div className={styles.checkbox}>
@@ -95,6 +138,7 @@ export const DateStep = ({ isMobile }: IDateStepProps) => {
           buttonType="primary"
           label="Продолжить"
           onClick={handleNextStepClick}
+          disabled={!time}
         />
       </div>
     </>

--- a/src/features/create-request/ui/steps/date-step/date-step.tsx
+++ b/src/features/create-request/ui/steps/date-step/date-step.tsx
@@ -51,30 +51,6 @@ export const DateStep = ({ isMobile }: IDateStepProps) => {
     dispatch(setTime(e.target.value));
     // setInputValue(e.target.value);
   };
-
-  // useEffect(() => {
-  //   const currentTime = new Date(); // текущая дата
-  //   const currentFormattedTime = format(currentTime, 'HH:mm'); // привожу в нужный формат
-  //   // const selectedTime = new Date(`1970-01-01T${time}:00`); //фиктивная дата '1970-01-01', чтобы установить только время, а не дату
-  //   // const selectedFormattedTime = format(selectedTime, 'HH:mm'); // привожу в нужный формат
-  //   if (time && time < currentFormattedTime) {
-  //     console.log('время меньше');
-  //     console.log(currentFormattedTime);
-  //
-  //     dispatch(setTime(currentFormattedTime));
-  //   } //сравниваю даты
-  // }, [time]);
-  // useEffect(() => {
-  //   const inputTime = new Date(inputValue);
-  //   const currentTime = new Date();
-  //
-  //   if (inputTime < currentTime) {
-  //     setIsTimePassed(true);
-  //   } else {
-  //     setIsTimePassed(false);
-  //   }
-  // }, [inputValue]);
-
   const handleNextStepClick = () => {
     dispatch(changeStepIncrement());
   };

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -58,7 +58,10 @@ export const Request = ({ isMobile = true }: RequestProps) => {
   if (!data) return null;
 
   return (
-    <OverlayingPopup isOpened={isPopupOpen} onClose={handleCloseClick}>
+    <OverlayingPopup
+      isOpened={isPopupOpen}
+      onClose={isOpen ? undefined : handleCloseClick}
+    >
       <div>
         <MainPopup
           name={data.fullname}
@@ -70,7 +73,10 @@ export const Request = ({ isMobile = true }: RequestProps) => {
           extClassName={isMobile ? styles.mainPopUpWrapperMobile : undefined}
         >
           {isOpen && (
-            <OverlayingPopup isOpened={isOpen} onClose={handleCloseClick}>
+            <OverlayingPopup
+              isOpened={isOpen}
+              onClose={isOpen ? () => setIsOpen(false) : undefined}
+            >
               <div>
                 <Tooltip
                   visible

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -24,12 +24,6 @@ import { Button } from '../../../../shared/ui/button';
 export interface RequestProps {
   isMobile?: boolean;
 }
-
-interface Coords {
-  right: number;
-  top: number;
-}
-
 export const Request = ({ isMobile = true }: RequestProps) => {
   const dispatch = useAppDispatch();
   const { currentStep, isPopupOpen } = useAppSelector(
@@ -38,30 +32,7 @@ export const Request = ({ isMobile = true }: RequestProps) => {
   const data = useAppSelector((state) => state.user.data);
   const { data: categories } = useGetCategoriesQuery('');
   const [isOpen, setIsOpen] = useState(false);
-  // const [popupPosion, setPopupPosion] = useState<Coords | null>(null);
-  // const buttonRef = useRef<HTMLDivElement>(null);
-  // const popupClose = useCallback(() => {
-  //   setIsOpen(false);
-  // }, [setIsOpen]);
-  //
-  // const getCoords = () => {
-  //   const box = buttonRef.current?.getBoundingClientRect();
-  //
-  //   if (box) {
-  //     setPopupPosion({
-  //       right: window.innerWidth - box.right - box.width * 0.7,
-  //       top: box.top + window.scrollY + box.height * 0.6,
-  //     });
-  //   }
-  // };
-  //
-  // useEffect(() => {
-  //   window.addEventListener('resize', getCoords);
-  //
-  //   return () => {
-  //     window.removeEventListener('resize', getCoords);
-  //   };
-  // }, []);
+
   const handleCloseClick = () => {
     dispatch(closePopup());
     dispatch(clearState());
@@ -96,13 +67,14 @@ export const Request = ({ isMobile = true }: RequestProps) => {
           phoneNumber={data.phone}
           handleCloseClick={() => setIsOpen(true)}
           isMobile={isMobile}
+          extClassName={isMobile ? styles.mainPopUpWrapperMobile : undefined}
         >
           {isOpen && (
             <OverlayingPopup isOpened={isOpen} onClose={handleCloseClick}>
               <div>
                 <Tooltip
                   visible
-                  extClassName={styles.modal}
+                  extClassName={isMobile ? styles.modalMobile : styles.modal}
                   pointerPosition="right"
                   elementStyles={{
                     zIndex: 11,

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -1,7 +1,11 @@
-import { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAppDispatch, useAppSelector } from 'app/hooks';
-import { closePopup, setCategoryList } from 'features/create-request/model';
+import {
+  setCategoryList,
+  closePopup,
+  clearState,
+} from 'features/create-request/model';
 import { MainPopup } from 'shared/ui/main-popup';
 import { OverlayingPopup } from 'shared/ui/overlaying-popup';
 import { CurrentPage } from '../../types';
@@ -11,6 +15,11 @@ import { CommonStep } from './common-step/common-step';
 import { DateStep } from './date-step/date-step';
 import { TaskStep } from './task-step/task-step';
 import { useGetCategoriesQuery } from 'services/categories-api';
+import { Tooltip } from '../../../../shared/ui/tooltip';
+import styles from './styles.module.css';
+import { CloseCrossIcon } from '../../../../shared/ui/icons/close-cross-icon';
+import { SquareButton } from '../../../../shared/ui/square-buttons';
+import { Button } from '../../../../shared/ui/button';
 
 export interface RequestProps {
   isMobile?: boolean;
@@ -23,9 +32,34 @@ export const Request = ({ isMobile = true }: RequestProps) => {
   );
   const data = useAppSelector((state) => state.user.data);
   const { data: categories } = useGetCategoriesQuery('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [popupPosion, setPopupPosion] = useState({ top: 0, right: 0 });
+  const myRef = useRef<HTMLDivElement>(null);
+  //
+  const calculateFilterPosition = useCallback(() => {
+    const buttonRect = myRef.current?.getBoundingClientRect();
 
+    if (buttonRect) {
+      setPopupPosion({ top: buttonRect.bottom, right: buttonRect.right });
+    }
+  }, []);
+  //
+  // useEffect(() => {
+  //   window.addEventListener('resize', calculateFilterPosition);
+  //
+  //   return () => {
+  //     window.removeEventListener('resize', calculateFilterPosition);
+  //   };
+  // }, []);
+  //
+  // const popupPositionStyles = {
+  //   top: `${popupPosion.top + 520}px`,
+  //   right: `${window.innerWidth - popupPosion.right - 900}px`,
+  // };
   const handleCloseClick = () => {
     dispatch(closePopup());
+    dispatch(clearState());
+    console.log('close');
   };
 
   const closeByEsc = (e: KeyboardEvent) => {
@@ -53,9 +87,35 @@ export const Request = ({ isMobile = true }: RequestProps) => {
         avatarLink={data.avatar}
         avatarName={data.fullname}
         phoneNumber={data.phone}
-        handleCloseClick={handleCloseClick}
+        handleCloseClick={() => setIsOpen(true)}
         isMobile={isMobile}
       >
+        {isOpen && (
+          <Tooltip
+            visible
+            extClassName={styles.modal}
+            pointerPosition="right"
+            // changeVisible={handleDeniedAccess}
+            // elementStyles={popupPositionStyles}
+          >
+            <div className={styles.closeWrapper}></div>
+            <div className={styles.text}>
+              Закрыть окно сейчас и удалить ранее внесенную информацию?
+            </div>
+            <div className={styles.buttonWrapper}>
+              <Button
+                buttonType="primary"
+                label="Вернуться"
+                onClick={() => setIsOpen(false)}
+              />
+              <Button
+                buttonType="primary"
+                label="Закрыть"
+                onClick={handleCloseClick}
+              />
+            </div>
+          </Tooltip>
+        )}
         {currentStep === CurrentPage.DATE_STEP && (
           <DateStep isMobile={isMobile} />
         )}

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -98,7 +98,11 @@ export const Request = ({ isMobile = true }: RequestProps) => {
           isMobile={isMobile}
         >
           {isOpen && (
-            <OverlayingPopup isOpened={isOpen} onClose={handleCloseClick}>
+            <OverlayingPopup
+              extClassName={styles.tooltipWrapper}
+              isOpened={isOpen}
+              onClose={handleCloseClick}
+            >
               <div>
                 <Tooltip
                   visible

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -97,39 +97,40 @@ export const Request = ({ isMobile = true }: RequestProps) => {
           handleCloseClick={() => setIsOpen(true)}
           isMobile={isMobile}
         >
-          {/*<OverlayingPopup isOpened={isOpen} onClose={handleCloseClick}>*/}
           {isOpen && (
-            <Tooltip
-              visible
-              extClassName={styles.modal}
-              pointerPosition="right"
-              // elementStyles={{
-              //   position: 'absolute',
-              //   top: `${popupPosion?.top}px`,
-              //   right: `${popupPosion?.right}px`,
-              // }}
-              // changeVisible={handleDeniedAccess}
-              // elementStyles={popupPositionStyles}
-            >
-              <div className={styles.closeWrapper}></div>
-              <div className={styles.text}>
-                Закрыть окно сейчас и удалить ранее внесенную информацию?
+            <OverlayingPopup isOpened={isOpen} onClose={handleCloseClick}>
+              <div>
+                <Tooltip
+                  visible
+                  extClassName={styles.modal}
+                  pointerPosition="right"
+                  // elementStyles={{
+                  //   position: 'absolute',
+                  //   top: `${popupPosion?.top}px`,
+                  //   right: `${popupPosion?.right}px`,
+                  // }}
+                  // changeVisible={handleDeniedAccess}
+                  // elementStyles={popupPositionStyles}
+                >
+                  <div className={styles.text}>
+                    Закрыть окно сейчас и удалить ранее внесенную информацию?
+                  </div>
+                  <div className={styles.buttonWrapper}>
+                    <Button
+                      buttonType="primary"
+                      label="Вернуться"
+                      onClick={() => setIsOpen(false)}
+                    />
+                    <Button
+                      buttonType="primary"
+                      label="Закрыть"
+                      onClick={handleCloseClick}
+                    />
+                  </div>
+                </Tooltip>
               </div>
-              <div className={styles.buttonWrapper}>
-                <Button
-                  buttonType="primary"
-                  label="Вернуться"
-                  onClick={() => setIsOpen(false)}
-                />
-                <Button
-                  buttonType="primary"
-                  label="Закрыть"
-                  onClick={handleCloseClick}
-                />
-              </div>
-            </Tooltip>
+            </OverlayingPopup>
           )}
-          {/*</OverlayingPopup>*/}
 
           {currentStep === CurrentPage.DATE_STEP && (
             <DateStep isMobile={isMobile} />

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -107,8 +107,6 @@ export const Request = ({ isMobile = true }: RequestProps) => {
                   elementStyles={{
                     zIndex: 11,
                   }}
-                  // changeVisible={handleDeniedAccess}
-                  // elementStyles={popupPositionStyles}
                 >
                   <div className={styles.text}>
                     Закрыть окно сейчас и удалить ранее внесенную информацию?

--- a/src/features/create-request/ui/steps/index.tsx
+++ b/src/features/create-request/ui/steps/index.tsx
@@ -38,30 +38,30 @@ export const Request = ({ isMobile = true }: RequestProps) => {
   const data = useAppSelector((state) => state.user.data);
   const { data: categories } = useGetCategoriesQuery('');
   const [isOpen, setIsOpen] = useState(false);
-  const [popupPosion, setPopupPosion] = useState<Coords | null>(null);
-  const buttonRef = useRef<HTMLDivElement>(null);
-  const popupClose = useCallback(() => {
-    setIsOpen(false);
-  }, [setIsOpen]);
-
-  const getCoords = () => {
-    const box = buttonRef.current?.getBoundingClientRect();
-
-    if (box) {
-      setPopupPosion({
-        right: window.innerWidth - box.right - box.width * 0.7,
-        top: box.top + window.scrollY + box.height * 0.6,
-      });
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('resize', getCoords);
-
-    return () => {
-      window.removeEventListener('resize', getCoords);
-    };
-  }, []);
+  // const [popupPosion, setPopupPosion] = useState<Coords | null>(null);
+  // const buttonRef = useRef<HTMLDivElement>(null);
+  // const popupClose = useCallback(() => {
+  //   setIsOpen(false);
+  // }, [setIsOpen]);
+  //
+  // const getCoords = () => {
+  //   const box = buttonRef.current?.getBoundingClientRect();
+  //
+  //   if (box) {
+  //     setPopupPosion({
+  //       right: window.innerWidth - box.right - box.width * 0.7,
+  //       top: box.top + window.scrollY + box.height * 0.6,
+  //     });
+  //   }
+  // };
+  //
+  // useEffect(() => {
+  //   window.addEventListener('resize', getCoords);
+  //
+  //   return () => {
+  //     window.removeEventListener('resize', getCoords);
+  //   };
+  // }, []);
   const handleCloseClick = () => {
     dispatch(closePopup());
     dispatch(clearState());
@@ -88,7 +88,7 @@ export const Request = ({ isMobile = true }: RequestProps) => {
 
   return (
     <OverlayingPopup isOpened={isPopupOpen} onClose={handleCloseClick}>
-      <div ref={buttonRef}>
+      <div>
         <MainPopup
           name={data.fullname}
           avatarLink={data.avatar}
@@ -98,21 +98,15 @@ export const Request = ({ isMobile = true }: RequestProps) => {
           isMobile={isMobile}
         >
           {isOpen && (
-            <OverlayingPopup
-              extClassName={styles.tooltipWrapper}
-              isOpened={isOpen}
-              onClose={handleCloseClick}
-            >
+            <OverlayingPopup isOpened={isOpen} onClose={handleCloseClick}>
               <div>
                 <Tooltip
                   visible
                   extClassName={styles.modal}
                   pointerPosition="right"
-                  // elementStyles={{
-                  //   position: 'absolute',
-                  //   top: `${popupPosion?.top}px`,
-                  //   right: `${popupPosion?.right}px`,
-                  // }}
+                  elementStyles={{
+                    zIndex: 11,
+                  }}
                   // changeVisible={handleDeniedAccess}
                   // elementStyles={popupPositionStyles}
                 >

--- a/src/features/create-request/ui/steps/styles.module.css
+++ b/src/features/create-request/ui/steps/styles.module.css
@@ -1,0 +1,13 @@
+.buttonWrapper {
+    display: flex;
+    margin-top: 20px;
+    justify-content: center;
+    gap: 20px;
+}
+
+
+.modal {
+    position: absolute;
+    top: calc(50% - 160px);
+    left: calc(50% - 125px);
+}

--- a/src/features/create-request/ui/steps/styles.module.css
+++ b/src/features/create-request/ui/steps/styles.module.css
@@ -11,3 +11,7 @@
     top: calc(50% - 160px);
     left: calc(50% - 125px);
 }
+
+.tooltipWrapper {
+    z-index: 60;
+}

--- a/src/features/create-request/ui/steps/styles.module.css
+++ b/src/features/create-request/ui/steps/styles.module.css
@@ -11,7 +11,3 @@
     top: calc(50% - 160px);
     left: calc(50% - 125px);
 }
-
-.tooltipWrapper {
-    z-index: 60;
-}

--- a/src/features/create-request/ui/steps/styles.module.css
+++ b/src/features/create-request/ui/steps/styles.module.css
@@ -4,10 +4,19 @@
     justify-content: center;
     gap: 20px;
 }
-
+.mainPopUpWrapperMobile {
+    height: 554px;
+    width: 300px;
+}
 
 .modal {
     position: absolute;
     top: calc(50% - 160px);
     left: calc(50% - 125px);
+}
+
+.modalMobile {
+    position: absolute;
+    top: calc(50% - 230px);
+    left: calc(50% - 265px);
 }

--- a/src/shared/ui/date-picker/index.tsx
+++ b/src/shared/ui/date-picker/index.tsx
@@ -73,6 +73,7 @@ export interface IDatePickerProps {
   extClassName?: string;
   minDate?: Date | null;
   inline?: boolean;
+  disabled?: boolean;
 }
 
 export function DatePicker({
@@ -83,10 +84,23 @@ export function DatePicker({
   extClassName,
   minDate = subDays(new Date(), 0),
   inline = true,
+  disabled,
 }: IDatePickerProps) {
   const handleOnChange = (date: Date) => {
     if (date) onChangeValue(date);
   };
+
+  interface MyCalendar {
+    children: React.ReactNode | React.ReactNode[] | undefined;
+  }
+
+  const calendarContainerDisabled = ({ children }: MyCalendar) => (
+    <div style={{ opacity: 0.5, pointerEvents: 'none' }}>{children}</div>
+  );
+
+  const calendarContainerActive = ({ children }: MyCalendar) => (
+    <div>{children}</div>
+  );
 
   return (
     <ReactDatePicker
@@ -109,6 +123,9 @@ export function DatePicker({
       dayClassName={() => styles.dataPicker__calendarWeekDay}
       minDate={minDate}
       customInput={<CustomInput value={undefined} onClick={undefined} />}
+      calendarContainer={
+        disabled ? calendarContainerDisabled : calendarContainerActive
+      }
     />
   );
 }

--- a/src/shared/ui/overlaying-popup/index.tsx
+++ b/src/shared/ui/overlaying-popup/index.tsx
@@ -29,14 +29,15 @@ export const OverlayingPopup = ({
         role="dialog"
         id="label"
       >
-        {/* Возможно не понадобится в будущем т.к. оверлей перекрывает содержимое модалки и делает невозможным нажатие кнопок. Без него задний фон затемняется а интерфейс не доступен*/}
-        {/* <div
-          className={classNames(styles.overlay)}
-          role="button"
-          tabIndex={0}
-          onClick={onClose}
-          aria-labelledby="label"
-        ></div> */}
+        {
+          <div
+            className={classNames(styles.overlay)}
+            role="button"
+            tabIndex={0}
+            onClick={onClose}
+            aria-labelledby="label"
+          ></div>
+        }
         {children}
       </div>
     </Portal>


### PR DESCRIPTION
Сделан этап закрытия попапа. Если реципиент закрывает попап на крестик или на оверлей, то отображается модальное окно "Закрыть окно сейчас и удалить ранее внесенную информацию?", где он может выбрать "Закрыть" - и данные формы будут удалены, или "Вернуться" и данные вернутся, а пользователь останется на прежнем месте.
Поправил мобильный вид попала. При публикации заявке пока что вывожу данные в консоль.