### PR TITLE
change-using-icons

### DIFF
--- a/src/entities/task/ui/task-list/index.tsx
+++ b/src/entities/task/ui/task-list/index.tsx
@@ -6,7 +6,6 @@ import { usePermission, useUser, useControlModal } from 'shared/hooks';
 import { RoundButton, Informer, Tooltip, Icon } from 'shared/ui';
 import { Routes } from 'shared/config';
 import { unauthorizedRecipientPopupMessage } from 'shared/libs/constants';
-import { CloseCrossIcon } from 'shared/ui/icons/close-cross-icon';
 import { TaskItem } from '../task';
 import {
   UserRole,
@@ -209,7 +208,7 @@ export const TaskList = ({
                   }}
                 >
                   <div className={styles.closeWrapper}>
-                    <CloseCrossIcon
+                    <Icon icon="CloseCrossIcon"
                       className={styles.closeIcon}
                       size="14"
                       color="blue"

--- a/src/entities/user/ui/user-info/unauthorized-user/index.tsx
+++ b/src/entities/user/ui/user-info/unauthorized-user/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'shared/ui';
-import { VkIcon } from 'shared/ui/icons/vk-icon';
+import { Icon } from 'shared/ui';
 import { handleRedirectVK } from 'shared/libs/utils';
 
 import styles from './styles.module.css';
@@ -9,7 +9,7 @@ export const UnauthorizedUser = () => {
     <Button
       buttonType="primary"
       actionType="submit"
-      customIcon={<VkIcon color="white" size="24" />}
+      customIcon={<Icon icon="VkIcon" color="white" size="24" />}
       label="Войти через ВКонтакте"
       size="extraLarge"
       onClick={() => handleRedirectVK()}

--- a/src/entities/user/ui/user-info/volunteer-info/index.tsx
+++ b/src/entities/user/ui/user-info/volunteer-info/index.tsx
@@ -1,7 +1,5 @@
 import classnames from 'classnames';
-
-import { BallsIcon } from 'shared/ui/icons/balls-icon';
-import { KeyIcon } from 'shared/ui/icons/key-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
 
@@ -18,12 +16,12 @@ export const VolunteerInfo = ({
 }: VolunteerInfoProps) => (
   <div className={classnames(extClassName, styles.volunteerInfo)}>
     <div className={styles.dataWrapper}>
-      <BallsIcon size="32" color="blue" />
+      <Icon icon="BallsIcon" size="32" color="blue" />
       <span className="text text_size_small">{score}</span>
     </div>
     {hasKey && (
       <div className={styles.dataWrapper}>
-        <KeyIcon size="24" color="blue" />
+        <Icon icon="KeyIcon" size="24" color="blue" />
         <span className="text text_size_small">{hasKey}</span>
       </div>
     )}

--- a/src/features/create-request/ui/steps/common-step/common-step.tsx
+++ b/src/features/create-request/ui/steps/common-step/common-step.tsx
@@ -11,7 +11,7 @@ import {
   clearState,
 } from 'features/create-request/model';
 import { Button } from 'shared/ui/button';
-import { LocationIcon } from 'shared/ui/icons/location-icon';
+import { Icon } from 'shared/ui';
 import { CategoriesBackground } from 'shared/ui/categories-background';
 import styles from './common-step.module.css';
 import { EditButton } from 'shared/ui/edit-button';
@@ -160,7 +160,7 @@ export const CommonStep = ({ isMobile }: ICommonStepProps) => {
               )}
             </div>
             <div className={styles.addressWrapper}>
-              <LocationIcon color="blue" />
+              <Icon icon="LocationIcon" color="blue" />
               <p className={classNames('m-0', 'text_size_medium')}>{address}</p>
             </div>
             <CategoriesBackground
@@ -220,7 +220,7 @@ export const CommonStep = ({ isMobile }: ICommonStepProps) => {
               ) : null}
             </div>
             <div className={styles.addressWrapper}>
-              <LocationIcon color="blue" />
+              <Icon icon="LocationIcon" color="blue" />
               <p className={classNames('m-0', 'text_size_medium')}>{address}</p>
               {isTypeEdit && (
                 <EditButton

--- a/src/features/filter/components/filter-cover/filter-cover.tsx
+++ b/src/features/filter/components/filter-cover/filter-cover.tsx
@@ -9,7 +9,7 @@ import { Breakpoints } from 'shared/config';
 import type { IFilterValues } from 'features/filter/types';
 
 import styles from './filter-cover.module.css';
-import { CloseCrossIcon } from 'shared/ui/icons/close-cross-icon';
+import { Icon } from 'shared/ui';
 import { defaultObjFilteres } from 'features/filter/consts';
 import { useSearchParams } from 'react-router-dom';
 
@@ -117,7 +117,7 @@ export const FilterCover = ({
               buttonType="secondary"
               size="medium"
               actionType="reset"
-              customIcon={<CloseCrossIcon color={'blue'} />}
+              customIcon={<Icon icon="CloseCrossIcon" color={'blue'} />}
             />
             <Button
               style={buttonStyle}

--- a/src/pages/policy/index.tsx
+++ b/src/pages/policy/index.tsx
@@ -2,12 +2,11 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { initTitleMarkdown, initDescriptionMarkdown } from './content';
 import style from './markdown-style.module.css';
-import { EditIcon } from '../../shared/ui/icons/edit-icon';
 import { ChangeEvent, SyntheticEvent, useState } from 'react';
 import { Button } from '../../shared/ui/button';
-import { CloseIconThin } from '../../shared/ui/icons/close-icon-thin';
 import { SmartHeader } from '../../shared/ui/smart-header';
-import { LockIcon } from '../../shared/ui/icons/lock-icon';
+import { Icon } from 'shared/ui';
+
 import { useMediaQuery } from '../../shared/hooks';
 import usePermission from '../../shared/hooks/use-permission';
 import { userRole } from 'shared/types/common.types';
@@ -49,7 +48,7 @@ export function PolicyPage() {
   return (
     <div className={style.wrapper}>
       <SmartHeader
-        icon={<LockIcon color="blue" size="32" />}
+        icon={<Icon icon="LockIcon" color="blue" size="32" />}
         text="Политика конфиденциальности"
         extClassName={isMobile ? style.smartHeaderOn : style.smartHeaderOff}
       />
@@ -64,7 +63,7 @@ export function PolicyPage() {
             </ReactMarkdown>
             {isMainAdmin && (
               <button className={style.editButton} onClick={handleEditButton}>
-                <EditIcon color={'blue'} size={'20'} height="18" />
+                <Icon icon="EditIcon" color={'blue'} size={'20'} height="18" />
                 <p className={style.editButtonText}>Редактировать</p>
               </button>
             )}
@@ -102,7 +101,7 @@ export function PolicyPage() {
               size="extraLarge"
             />
             <button className={style.closeButton} onClick={handleCloseButton}>
-              <CloseIconThin color={'blue'}></CloseIconThin>
+              <Icon icon="CloseIconThin" color={'blue'} />
               <p className={style.closeButtonText}>Закрыть без изменений</p>
             </button>
           </div>

--- a/src/shared/ui/button/button.stories.tsx
+++ b/src/shared/ui/button/button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '.';
-import { VkIcon } from '../icons/vk-icon';
+import { Icon } from 'shared/ui';
 
 const meta: Meta<typeof Button> = {
   title: 'uikit/Buttons/Button',
@@ -51,6 +51,6 @@ export const WithIcon: Story = {
     buttonType: 'primary',
     label: 'Войти через ВКонтакте',
     size: 'extraLarge',
-    customIcon: <VkIcon size="24" color="white" />,
+    customIcon: <Icon icon="VkIcon" size="24" color="white" />,
   },
 };

--- a/src/shared/ui/card-button/card-button.stories.tsx
+++ b/src/shared/ui/card-button/card-button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { CardButton } from '.';
-import { CompletedApplicationIcon } from '../icons/completed-application-icon';
+import { Icon } from 'shared/ui';
 
 const meta: Meta<typeof CardButton> = {
   title: 'uikit/Buttons/CardButton',
@@ -14,18 +14,18 @@ const meta: Meta<typeof CardButton> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const Icon = <CompletedApplicationIcon size="54" color="white" />;
+const Icon_ = <Icon icon="CompletedApplicationIcon" size="54" color="white" />;
 
 export const Default: Story = {
   args: {
     text: 'Обозначение карточки',
-    customIcon: Icon,
+    customIcon: Icon_,
   },
 };
 
 export const Pressed: Story = {
   args: {
     text: 'Обозначение карточки',
-    customIcon: Icon,
+    customIcon: Icon_,
   },
 };

--- a/src/shared/ui/dropdown/index.tsx
+++ b/src/shared/ui/dropdown/index.tsx
@@ -1,13 +1,8 @@
 import { createRef, useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
-
-import { CheckIcon } from '../icons/check-icon';
-import { ArrowDownIcon } from '../icons/arrow-down-icon';
-
+import { Icon } from 'shared/ui';
 import styles from './styles.module.css';
 import { useAppSelector } from 'app/hooks';
-
-import { CloseCrossIcon } from '../icons/close-cross-icon';
 import { Tooltip } from '../tooltip';
 import { Task } from 'entities/task/types';
 import { useGetTaskActiveQuery } from 'services/user-task-api';
@@ -100,7 +95,7 @@ const Dropdown = ({
         {!isActive && (
           <>
             {selected?.title || placeholder}
-            {selected && <ArrowDownIcon color={'white'} />}
+            {selected && <Icon icon="ArrowDownIcon" color={'white'} />}
           </>
         )}
       </div>
@@ -124,7 +119,7 @@ const Dropdown = ({
                 }}
               >
                 {item?.title}
-                {selected?._id === item._id && <CheckIcon color={'blue'} />}
+                {selected?._id === item._id && <Icon icon="CheckIcon" color={'blue'} />}
               </li>
             );
           })}
@@ -142,7 +137,7 @@ const Dropdown = ({
           }}
         >
           <div className={styles.closeWrapper}>
-            <CloseCrossIcon
+            <Icon icon="CloseCrossIcon"
               className={styles.closeIcon}
               size="14"
               color="blue"

--- a/src/shared/ui/edit-button/index.tsx
+++ b/src/shared/ui/edit-button/index.tsx
@@ -1,7 +1,6 @@
 import type { ButtonHTMLAttributes } from 'react';
 import classnames from 'classnames';
-
-import { EditIcon } from '../icons/edit-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
 
@@ -28,7 +27,7 @@ export const EditButton = ({
     {...props}
   >
     <div className={styles['edit-buttonContent']}>
-      <EditIcon size="24" color="blue" />
+      <Icon icon="EditIcon" size="24" color="blue" />
       <span>{label}</span>
     </div>
   </button>

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -57,6 +57,7 @@ import { CloseIconThin } from './close-icon-thin';
 import { UnionIcon } from './union-icon';
 import { FileAttachmentIcon } from './file-attachment-icon';
 
+
 const icons = {
   ExcelIcon,
   ExclamationPMark,

--- a/src/shared/ui/light-popup/index.tsx
+++ b/src/shared/ui/light-popup/index.tsx
@@ -1,5 +1,5 @@
 import { OverlayingPopup } from 'shared/ui/overlaying-popup';
-import { CloseCrossIcon } from '../icons/close-cross-icon';
+import { Icon } from 'shared/ui';
 import { ReactNode } from 'react';
 import classNames from 'classnames';
 
@@ -29,7 +29,7 @@ export const LightPopup = ({
       <div className={classNames(styles.container, extClassName, 'text')}>
         {hasCloseButton && (
           <button className={styles.closeButton} onClick={onClickExit}>
-            <CloseCrossIcon color={'blue'} />
+            <Icon icon="CloseCrossIcon" color={'blue'} />
           </button>
         )}
         {children}

--- a/src/shared/ui/post-form/PostForm.tsx
+++ b/src/shared/ui/post-form/PostForm.tsx
@@ -4,8 +4,7 @@ import { useForm } from 'react-hook-form';
 
 import { Button } from '../button';
 import { TextArea } from '../text-area';
-import { FileAttachmentIcon } from '../icons/file-attachment-icon';
-import { CloseCrossIcon } from '../icons/close-cross-icon';
+import { Icon } from 'shared/ui';
 import { fileTypes } from 'shared/types/common.types';
 import { FormInput } from '../form-input';
 import useFormField from 'shared/hooks/use-form-field';
@@ -129,7 +128,7 @@ export const PostForm: FC<PostFormProps> = ({
           error={textField.error}
         />
         <label className={styles['attachment-button']}>
-          <FileAttachmentIcon size="24" color="white" />
+          <Icon icon="FileAttachmentIcon" size="24" color="white" />
           <input
             className={styles['input-file']}
             type="file"
@@ -147,11 +146,11 @@ export const PostForm: FC<PostFormProps> = ({
         {images &&
           images.map(({ id, name }) => (
             <div className={styles.image} key={id}>
-              <FileAttachmentIcon size="14" color="white" />
+              <Icon icon="FileAttachmentIcon" size="14" color="white" />
               <p className={imageTitleStyle}>{name}</p>
               <Button
                 buttonType="secondary"
-                customIcon={<CloseCrossIcon size="14" color="blue" />}
+                customIcon={<Icon icon="CloseCrossIcon" size="14" color="blue" />}
                 extClassName={styles['close-cross-button']}
                 onClick={() => removeAttachment(id)}
                 type="button"

--- a/src/shared/ui/round-button/index.tsx
+++ b/src/shared/ui/round-button/index.tsx
@@ -1,10 +1,7 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import classnames from 'classnames';
-
-import { PhoneIcon } from '../icons/phone-icon';
-import { EmptyMessageIcon } from '../icons/empty-message-icon';
-import { LocationIcon } from '../icons/location-icon';
-import { AddMediumIcon, AddLargeIcon } from '../icons/add-icon';
+import { AddLargeIcon } from '../icons/add-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
 
@@ -24,10 +21,10 @@ interface RoundButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const defautlIcons = {
-  phone: <PhoneIcon size="24" color="white" />,
-  message: <EmptyMessageIcon size="24" color="white" />,
-  location: <LocationIcon size="54" color="white" />,
-  addMedium: <AddMediumIcon size="48" color="white" />,
+  phone: <Icon icon="PhoneIcon" size="24" color="white" />,
+  message: <Icon icon="EmptyMessageIcon" size="24" color="white" />,
+  location: <Icon icon="LocationIcon" size="54" color="white" />,
+  addMedium: <Icon icon="AddMediumIcon" size="48" color="white" />,
   addLarge: <AddLargeIcon size="66" color="white" />,
   default: null,
 };

--- a/src/shared/ui/smart-header/smart-header.stories.tsx
+++ b/src/shared/ui/smart-header/smart-header.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { SmartHeader } from '.';
-
-import { ActiveApplicationIcon } from '../icons/active-application-icon';
+import { Icon } from 'shared/ui';
 
 const meta: Meta<typeof SmartHeader> = {
   title: 'uikit/SmartHeader',
@@ -25,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Filled: Story = {
   args: {
-    icon: <ActiveApplicationIcon color="blue" />,
+    icon: <Icon icon="ActiveApplicationIcon" color="blue" />,
     text: 'Активные заявки',
   },
 };

--- a/src/shared/ui/square-buttons/index.tsx
+++ b/src/shared/ui/square-buttons/index.tsx
@@ -1,12 +1,8 @@
 import type { ReactNode, ButtonHTMLAttributes } from 'react';
 import classnames from 'classnames';
-
-import { EditIcon } from '../icons/edit-icon';
-import { CloseIcon } from '../icons/close-icon';
-import { DoneIcon } from '../icons/done-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
-import { ConflictIcon } from '../icons/conflict-icon';
 import { ConflictMessageIcon } from '../icons/conflict-message-icon';
 
 interface SquareButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -19,10 +15,10 @@ interface SquareButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const defaultIcons = {
-  close: <CloseIcon size="24" color="white" />,
-  edit: <EditIcon size="24" color="white" />,
-  confirm: <DoneIcon size="24" color="white" />,
-  conflict: <ConflictIcon size="24" color="white" />,
+  close: <Icon icon="CloseIcon" size="24" color="white" />,
+  edit: <Icon icon="EditIcon" size="24" color="white" />,
+  confirm: <Icon icon="DoneIcon" size="24" color="white" />,
+  conflict: <Icon icon="ConflictIcon" size="24" color="white" />,
   message: <ConflictMessageIcon size="24" color="white" />,
 };
 

--- a/src/shared/ui/user-cards/components/admin-actions/dropdown.tsx
+++ b/src/shared/ui/user-cards/components/admin-actions/dropdown.tsx
@@ -1,9 +1,8 @@
 import { Control, Controller } from 'react-hook-form';
 
 import { Button, Checkbox } from 'shared/ui';
-import { ArrowDownIcon } from 'shared/ui/icons/arrow-down-icon';
 import { adminPermission, AdminPermission } from 'shared/types/common.types';
-
+import { Icon } from 'shared/ui';
 import styles from '../../styles.module.css';
 
 interface AdminDropdownMenuProps {
@@ -25,7 +24,7 @@ export const AdminDropdownMenu = ({
         className={styles.admin_arrow_up}
         onClick={() => setAdminDropdownListClosed(true)}
       >
-        <ArrowDownIcon color="blue" onClick={onSwitchArrow} />
+        <Icon icon="ArrowDownIcon" color="blue" onClick={onSwitchArrow} />
       </div>
       <div className={styles.admin_checkboxes}>
         <Controller

--- a/src/shared/ui/user-cards/components/admin-actions/index.tsx
+++ b/src/shared/ui/user-cards/components/admin-actions/index.tsx
@@ -3,8 +3,7 @@ import { useForm } from 'react-hook-form';
 
 import { Input, Button } from 'shared/ui';
 import { useControlModal } from 'shared/hooks';
-import { EditIcon } from 'shared/ui/icons/edit-icon';
-import { ArrowDownIcon } from 'shared/ui/icons/arrow-down-icon';
+import { Icon } from 'shared/ui';
 import { AdminPermission } from 'shared/types/common.types';
 import {
   useAddAdminPrivilegiesMutation,
@@ -106,7 +105,7 @@ const AdminActions = ({
           type={'password'}
           disabled
         />
-        <EditIcon
+        <Icon icon="EditIcon"
           onClick={handleModalOpen}
           className={styles.admin_edit_icon}
           color={'blue'}
@@ -128,7 +127,7 @@ const AdminActions = ({
               className={styles.admin_arrow_down}
               onClick={() => setAdminDropdownListClosed(false)}
             >
-              <ArrowDownIcon color={'blue'} onClick={onSwitchArrow} />
+              <Icon icon="ArrowDownIcon" color={'blue'} onClick={onSwitchArrow} />
             </div>
           </div>
         </>

--- a/src/shared/ui/user-cards/components/admin-actions/reset-password.tsx
+++ b/src/shared/ui/user-cards/components/admin-actions/reset-password.tsx
@@ -1,7 +1,7 @@
 import { Input } from 'shared/ui/input';
 import { Button } from 'shared/ui/button';
 import styles from '../../styles.module.css';
-import { CloseIconThin } from 'shared/ui/icons/close-icon-thin';
+import { Icon } from 'shared/ui';
 import { useForm, SubmitHandler } from 'react-hook-form';
 
 interface ResetPasswordProps {
@@ -26,7 +26,7 @@ export const ResetPassword = ({ handleModalClose }: ResetPasswordProps) => {
     <div className={styles.modalContainer}>
       <div className={styles.modalContent}>
         <h2 className={styles.modalTitle}>Смена пароля</h2>
-        <CloseIconThin
+        <Icon icon="CloseIconThin"
           className={styles.close}
           onClick={handleModalClose}
           color="blue"

--- a/src/shared/ui/user-cards/components/volonteer-actions.tsx
+++ b/src/shared/ui/user-cards/components/volonteer-actions.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { ExclamationPointIcon } from 'shared/ui/icons/exclamation-point-icon';
 import { Button } from 'shared/ui/button';
 import { VolunteerInfo } from 'entities/user/ui/user-info/volunteer-info';
-
 import styles from '../styles.module.css';
 import { useAppSelector } from '../../../../app/hooks';
 import { adminPermission, UserStatus } from '../../../types/common.types';

--- a/src/shared/ui/view-mode-button/index.tsx
+++ b/src/shared/ui/view-mode-button/index.tsx
@@ -1,8 +1,7 @@
 import type { ButtonHTMLAttributes } from 'react';
 import classnames from 'classnames';
 
-import { ListIcon } from '../icons/list-icon';
-import { TilesIcon } from '../icons/tiles-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
 
@@ -14,8 +13,8 @@ interface ViewModeButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const iconMap = {
-  list: <ListIcon color="blue" />,
-  tiles: <TilesIcon color="blue" />,
+  list: <Icon icon="ListIcon" color="blue" />,
+  tiles: <Icon icon="TilesIcon" color="blue" />,
 };
 
 export const ViewModeButton = ({

--- a/src/widgets/balance-settings/components/balance-settings-item.tsx
+++ b/src/widgets/balance-settings/components/balance-settings-item.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent } from 'react';
 
 import { Input } from 'shared/ui';
-import { BallsIcon } from 'shared/ui/icons/balls-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
 
@@ -28,7 +28,7 @@ const BalanceSettingsItem = ({
         min="1"
         step="1"
       />
-      <BallsIcon color="blue" size="46" />
+      <Icon icon="BallsIcon" color="blue" size="46" />
     </div>
   );
 };

--- a/src/widgets/button-with-modal/index.tsx
+++ b/src/widgets/button-with-modal/index.tsx
@@ -1,6 +1,6 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useRef, useState } from 'react';
-import { CloseCrossIcon } from 'shared/ui/icons/close-cross-icon';
+import { Icon } from 'shared/ui';
 import { Tooltip } from 'shared/ui/tooltip';
 import styles from './styles.module.css';
 
@@ -71,7 +71,7 @@ export const ButtonWithModal = ({
           }}
         >
           {closeButton && (
-            <CloseCrossIcon
+            <Icon icon="CloseCrossIcon"
               color="blue"
               className={`${styles.closeButton} close`}
             />

--- a/src/widgets/header/components/menu-button/index.tsx
+++ b/src/widgets/header/components/menu-button/index.tsx
@@ -1,7 +1,5 @@
 import { SyntheticEvent } from 'react';
-
-import { MenuIcon } from 'shared/ui/icons/menu-icon';
-import { UnionIcon } from 'shared/ui/icons/union-icon';
+import { Icon } from 'shared/ui';
 
 import styles from './styles.module.css';
 
@@ -13,12 +11,12 @@ interface IMenuButtonProps {
 const MenuButton = ({ onClick, isMobile }: IMenuButtonProps) => {
   return (
     <button onClick={onClick} className={styles.header__button}>
-      {isMobile && <MenuIcon color="blue" />}
+      {isMobile && <Icon icon="MenuIcon" color="blue" />}
 
       {!isMobile && (
         <div className={styles.header__button__container}>
           <span className={styles.header__button__text}>Меню</span>
-          <UnionIcon color="blue" />
+          <Icon icon="UnionIcon" color="blue" />
         </div>
       )}
     </button>

--- a/src/widgets/header/navigation/side-bar.stories.tsx
+++ b/src/widgets/header/navigation/side-bar.stories.tsx
@@ -1,10 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
 
-import { WriteMessageIcon } from 'shared/ui/icons/write-message-icon';
-import { PersonIcon } from 'shared/ui/icons/person-icon';
-import { LockIcon } from 'shared/ui/icons/lock-icon';
-import { LocationIcon } from 'shared/ui/icons/location-icon';
+import { Icon } from 'shared/ui';
 
 import { SideBar } from './index';
 
@@ -30,22 +27,22 @@ export const Playground: Story = {
       {
         title: 'Личный кабинет',
         to: '/profile',
-        icon: <PersonIcon color="blue" />,
+        icon: <Icon icon="PersonIcon" color="blue" />,
       },
       {
         title: 'Блог',
         to: '/blog',
-        icon: <WriteMessageIcon color="blue" />,
+        icon: <Icon icon="WriteMessageIcon" color="blue" />,
       },
       {
         title: 'Политика конфиденциальности',
         to: '/policy',
-        icon: <LockIcon color="blue" />,
+        icon: <Icon icon="LockIcon" color="blue" />,
       },
       {
         title: 'Контакты',
         to: '/contacts',
-        icon: <LocationIcon color="blue" />,
+        icon: <Icon icon="LocationIcon" color="blue" />,
       },
     ],
     position: {

--- a/src/widgets/header/utils.tsx
+++ b/src/widgets/header/utils.tsx
@@ -1,13 +1,9 @@
-import { WriteMessageIcon } from 'shared/ui/icons/write-message-icon';
-import { PersonIcon } from 'shared/ui/icons/person-icon';
-import { LockIcon } from 'shared/ui/icons/lock-icon';
-import { LocationIcon } from 'shared/ui/icons/location-icon';
+import { Icon } from 'shared/ui';
 import { Routes } from '../../shared/config';
 import type {
   ISideBarElementProps,
   ISideBarPosition,
 } from 'widgets/header/navigation/types';
-import { ReadMessageIcon } from 'shared/ui/icons/read-message-icon';
 
 export const positionConfigTop: ISideBarPosition = {
   ulflexDirection: 'row',
@@ -36,22 +32,22 @@ export const linksTop: ISideBarElementProps[] = [
   {
     title: 'Личный кабинет',
     to: `${Routes.PROFILE}`,
-    icon: <PersonIcon color="blue" />,
+    icon: <Icon icon="PersonIcon" color="blue" />,
   },
   {
     title: 'Блог',
     to: `${Routes.BLOG}`,
-    icon: <WriteMessageIcon color="blue" />,
+    icon: <Icon icon="WriteMessageIcon" color="blue" />,
   },
   {
     title: 'Политика конфиденциальности',
     to: `${Routes.POLICY}`,
-    icon: <LockIcon color="blue" />,
+    icon: <Icon icon="LockIcon" color="blue" />,
   },
   {
     title: 'Контакты',
     to: `${Routes.CONTACTS}`,
-    icon: <LocationIcon color="blue" />,
+    icon: <Icon icon="LocationIcon" color="blue" />,
   },
 ];
 
@@ -59,22 +55,22 @@ export const linksTopAuthUser: ISideBarElementProps[] = [
   {
     title: 'Личный кабинет',
     to: `${Routes.PROFILE}`,
-    icon: <PersonIcon color="blue" />,
+    icon: <Icon icon="PersonIcon" color="blue" />,
   },
   {
     title: 'Блог',
     to: `${Routes.BLOG}`,
-    icon: <WriteMessageIcon color="blue" />,
+    icon: <Icon icon="WriteMessageIcon" color="blue" />,
   },
   {
     title: 'Политика конфиденциальности',
     to: `${Routes.POLICY}`,
-    icon: <LockIcon color="blue" />,
+    icon: <Icon icon="LockIcon" color="blue" />,
   },
   {
     title: 'Контакты',
     to: `${Routes.CONTACTS}`,
-    icon: <LocationIcon color="blue" />,
+    icon: <Icon icon="LocationIcon" color="blue" />,
   },
 ];
 
@@ -82,27 +78,27 @@ export const linksTopAuthAdmin: ISideBarElementProps[] = [
   {
     title: 'Личный кабинет',
     to: `${Routes.PROFILE}`,
-    icon: <PersonIcon color="blue" />,
+    icon: <Icon icon="PersonIcon" color="blue" />,
   },
   {
     title: 'Блог',
     to: `${Routes.BLOG}`,
-    icon: <WriteMessageIcon color="blue" />,
+    icon: <Icon icon="WriteMessageIcon" color="blue" />,
   },
   {
     title: 'Политика конфиденциальности',
     to: `${Routes.POLICY}`,
-    icon: <LockIcon color="blue" />,
+    icon: <Icon icon="LockIcon" color="blue" />,
   },
   {
     title: 'Контакты',
     to: `${Routes.CONTACTS}`,
-    icon: <LocationIcon color="blue" />,
+    icon: <Icon icon="LocationIcon" color="blue" />,
   },
   {
     title: 'Чат',
     to: `${Routes.CHAT_HUB}`,
-    icon: <ReadMessageIcon color="blue" />,
+    icon: <Icon icon="ReadMessageIcon" color="blue" />,
   },
 ];
 
@@ -110,21 +106,21 @@ export const linksMenuMobileUnauthorized: ISideBarElementProps[] = [
   {
     title: 'Личный кабинет',
     to: `${Routes.PROFILE}`,
-    icon: <PersonIcon color="blue" />,
+    icon: <Icon icon="PersonIcon" color="blue" />,
   },
   {
     title: 'Блог',
     to: `${Routes.BLOG}`,
-    icon: <WriteMessageIcon color="blue" />,
+    icon: <Icon icon="WriteMessageIcon" color="blue" />,
   },
   {
     title: 'Политика конфиденциальности',
     to: `${Routes.POLICY}`,
-    icon: <LockIcon color="blue" />,
+    icon: <Icon icon="LockIcon" color="blue" />,
   },
   {
     title: 'Контакты',
     to: `${Routes.CONTACTS}`,
-    icon: <LocationIcon color="blue" />,
+    icon: <Icon icon="LocationIcon" color="blue" />,
   },
 ];

--- a/src/widgets/map/index.tsx
+++ b/src/widgets/map/index.tsx
@@ -17,8 +17,7 @@ import {
   cantAssignTaskMessage,
   unauthorizedUserPopupMessage,
 } from 'shared/libs/constants';
-import { ConflictIcon } from 'shared/ui/icons/conflict-icon';
-import { FinishedApplicationIcon } from 'shared/ui/icons/finished-application-icon';
+import { Icon } from 'shared/ui';
 
 import type { Task } from 'entities/task/types';
 import { GeoCoordinates } from 'shared/types/point-geojson.types';
@@ -187,7 +186,7 @@ export const YandexMap = ({
               {thankForAssignTaskMessage}
             </p>
             <p className={classNames(styles.popupIcon, 'text_size_large')}>
-              <FinishedApplicationIcon color="#9798C9" size="101" />
+              <Icon icon="FinishedApplicationIcon" color="#9798C9" size="101" />
             </p>
           </LightPopup>
           <LightPopup
@@ -197,7 +196,7 @@ export const YandexMap = ({
             extClassName={styles.container_sorry}
           >
             <p className={classNames(styles.popupTitle, 'text_size_large')}>
-              <ConflictIcon color="orange" />
+              <Icon icon="ConflictIcon" color="orange" />
               Извините
             </p>
             <p className={classNames(styles.popupText)}>

--- a/src/widgets/user-card/components/admin-actions.tsx
+++ b/src/widgets/user-card/components/admin-actions.tsx
@@ -3,9 +3,8 @@ import classnames from 'classnames';
 
 import Checkbox from 'shared/ui/checkbox';
 import { Input } from 'shared/ui/input';
-import { EditIcon } from 'shared/ui/icons/edit-icon';
 import { Button } from 'shared/ui/button';
-import { ArrowDownIcon } from 'shared/ui/icons/arrow-down-icon';
+import { Icon } from 'shared/ui';
 
 import styles from '../styles.module.css';
 
@@ -46,7 +45,7 @@ const AdminActions = ({
           placeholder="Пароль"
           type="password"
         />
-        <EditIcon
+        <Icon icon="EditIcon"
           className={classnames(styles.admin_edit_icon)}
           color={'blue'}
         />
@@ -66,7 +65,7 @@ const AdminActions = ({
               className={classnames(styles.admin_arrow_down)}
               onClick={() => setAdminDropdownListClosed(false)}
             >
-              <ArrowDownIcon color={'blue'} />
+              <Icon icon="ArrowDownIcon" color={'blue'} />
             </div>
           </div>
         </>
@@ -76,7 +75,7 @@ const AdminActions = ({
             className={classnames(styles.admin_arrow_up)}
             onClick={() => setAdminDropdownListClosed(true)}
           >
-            <ArrowDownIcon color={'blue'} />
+            <Icon icon="ArrowDownIcon" color={'blue'} />
           </div>
           <div className={classnames(styles.admin_checkboxes)}>
             <Checkbox


### PR DESCRIPTION
**DefaultCheckboxIcon, ConflictMessageIcon, AddLargeIcon** -- нет в списке значений поля icon у <Icon>
———————————————
**RenderIcon** тоже нет в списке и он используется по-другому вот контекст кода:
export function Icon({ icon, ...props }: IconProps) {
  const RenderIcon = useMemo(() => icons[icon], [icon]);
  return <RenderIcon {...props} />;
}
А для кого, чтобы адаптировать эти иконки под <Icon> необходимо поле color:
**AccordionIconArrow, ExclamationPointIcon** для него необходимо свойство цвета
