### PR TITLE
Обновление handleSubmit в аdminАctions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ yarn-error.log*
 storybook-static
 .cache
 *storybook.log
+
+.env.dev

--- a/src/services/admin-api.ts
+++ b/src/services/admin-api.ts
@@ -161,6 +161,7 @@ export const adminsApi = createApi({
         method: 'PATCH',
         body: { privileges: body },
       }),
+      invalidatesTags: [{ type: 'Admins' }],
     }),
     blockAdmin: build.mutation<{ id: string }, string>({
       query: (id) => ({

--- a/src/shared/ui/user-cards/components/admin-actions/index.tsx
+++ b/src/shared/ui/user-cards/components/admin-actions/index.tsx
@@ -71,7 +71,7 @@ const AdminActions = ({
 
     const result = keysArray.filter((key) => values[key]);
 
-    await addAdminPrivileges({ _id: id, result });
+    await addAdminPrivileges({ _id: id, body: result });
   };
 
   const handleBlock = async () => {


### PR DESCRIPTION
Необходимо открыть ещё один тикет! Проблема заключается в том, что при взаимодействии с одним администратором (например, при изменении привилегий), обновляются все карточки администраторов. Это связано с тем, что состояния привилегий для каждого администратора не разделены. 